### PR TITLE
Make emulate()'s stop_when parameter mandatory

### DIFF
--- a/pioemu/__init__.py
+++ b/pioemu/__init__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "0.1.0"
+__version__ = "0.22.0"
 
 from .conditions import clock_cycles_reached
 from .emulation import emulate

--- a/pioemu/emulation.py
+++ b/pioemu/emulation.py
@@ -20,13 +20,14 @@ from .shifter import shift_left, shift_right
 def emulate(
     opcodes,
     *,
+    stop_when,
     initial_state=State(),
-    stop_when=None,
     shift_osr_right=True,
     side_set_base=0,
     side_set_count=0,
 ):
-    stop_when = stop_when or (lambda state: False)
+    if stop_when is None:
+        raise ValueError("emulate() missing value for keyword argument: 'stop_when'")
 
     if shift_osr_right:
         instruction_decoder = InstructionDecoder(shift_right)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rp2040-pio-emulator"
-version = "0.21.0"
+version = "0.22.0"
 description = "RP2040 emulator for the testing and debugging of PIO programs"
 authors = ["Nathan Young"]
 license = "Apache-2.0"

--- a/tests/test_emulation.py
+++ b/tests/test_emulation.py
@@ -16,9 +16,14 @@ from pioemu import clock_cycles_reached, emulate, State
 from .support import emulate_single_instruction
 
 
+def test_stop_when_requires_value():
+    with pytest.raises(ValueError):
+        next(emulate([0x0000], stop_when=None))
+
+
 def test_emulation_stops_when_unsupported_opcode_is_reached():
     with pytest.raises(StopIteration):
-        next(emulate([0xE0E0]))
+        next(emulate([0xE0E0], stop_when=lambda _: False))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
stop_when is now a required argument. This ensures that any infinite
loops are explicitly expressed within calling code instead of implicit.