### PR TITLE
Fix the deprection warnings in the CI Pipeline

### DIFF
--- a/.github/workflows/package-ci.yml
+++ b/.github/workflows/package-ci.yml
@@ -11,10 +11,10 @@ jobs:
         python-version: [3.7, 3.8, 3.9, 3.10.10]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
Updates some of the actions to newer versions (using NodeJS 16 rather than the deprecated NodeJS 12) to eliminate those issues and prevent them from becoming problems later on