### PR TITLE
Add type hints to source code

### DIFF
--- a/docs/images/coverage-badge.svg
+++ b/docs/images/coverage-badge.svg
@@ -17,7 +17,7 @@
         <text x="32.5" y="14">coverage</text>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
-        <text x="89.0" y="15" fill="#010101" fill-opacity=".3">98.9%</text>
-        <text x="88.0" y="14">98.9%</text>
+        <text x="89.0" y="15" fill="#010101" fill-opacity=".3">98.6%</text>
+        <text x="88.0" y="14">98.6%</text>
     </g>
 </svg>

--- a/pioemu/conditions.py
+++ b/pioemu/conditions.py
@@ -11,45 +11,49 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-def clock_cycles_reached(target_value):
+from typing import Callable, Literal
+from .state import State
+
+
+def clock_cycles_reached(target_value: int) -> Callable[[int, State], bool]:
     return lambda _, state: state.clock >= target_value
 
 
-def always(_):
+def always(_: State) -> Literal[True]:
     return True
 
 
-def gpio_low(pin_number, state):
+def gpio_low(pin_number: int, state: State) -> bool:
     return not gpio_high(pin_number, state)
 
 
-def gpio_high(pin_number, state):
-    return state.pin_values & (1 << pin_number)
+def gpio_high(pin_number: int, state: State) -> bool:
+    return state.pin_values & (1 << pin_number) != 0
 
 
-def transmit_fifo_not_empty(state):
+def transmit_fifo_not_empty(state: State) -> bool:
     return len(state.transmit_fifo) > 0
 
 
-def x_register_equals_zero(state):
+def x_register_equals_zero(state: State) -> bool:
     return state.x_register == 0
 
 
-def x_register_not_equal_to_zero(state):
+def x_register_not_equal_to_zero(state: State) -> bool:
     return state.x_register != 0
 
 
-def y_register_equals_zero(state):
+def y_register_equals_zero(state: State) -> bool:
     return state.y_register == 0
 
 
-def y_register_not_equal_to_zero(state):
+def y_register_not_equal_to_zero(state: State) -> bool:
     return state.y_register != 0
 
 
-def x_register_not_equal_to_y_register(state):
+def x_register_not_equal_to_y_register(state: State) -> bool:
     return state.x_register != state.y_register
 
 
-def output_shift_register_not_empty(state):
+def output_shift_register_not_empty(state: State) -> bool:
     return state.output_shift_register.counter != 32

--- a/pioemu/instruction.py
+++ b/pioemu/instruction.py
@@ -27,5 +27,5 @@ class ProgramCounterAdvance(Enum):
 @dataclass(frozen=True)
 class Instruction:
     condition: Callable[[State], bool]
-    callable: Callable[[int, State], State]
+    callable: Callable[[State], State]
     program_counter_advance: ProgramCounterAdvance

--- a/pioemu/instructions/pull.py
+++ b/pioemu/instructions/pull.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Nathan Young
+# Copyright 2021, 2023 Nathan Young
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,17 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from dataclasses import replace
-from pioemu.state import ShiftRegister
+from pioemu.state import ShiftRegister, State
 from pioemu.conditions import transmit_fifo_not_empty
 
 
-def pull_blocking(state):
+def pull_blocking(state: State) -> State:
     return replace(
         state, output_shift_register=ShiftRegister(state.transmit_fifo.pop(), 0)
     )
 
 
-def pull_nonblocking(state):
+def pull_nonblocking(state: State) -> State:
     if transmit_fifo_not_empty(state):
         new_contents = state.transmit_fifo.pop()
     else:

--- a/pioemu/primitive_operations.py
+++ b/pioemu/primitive_operations.py
@@ -12,16 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from dataclasses import replace
-from .state import ShiftRegister
+from typing import Any, Callable, Tuple
+from .state import ShiftRegister, State
 
 
-def read_from_isr(state):
+def read_from_isr(state: State) -> int:
     """Reads the contents of the input shift register."""
 
     return state.input_shift_register.contents
 
 
-def shift_into_isr(data_supplier, shift_method, bit_count, state):
+def shift_into_isr(
+    data_supplier: Callable[[State], int],
+    shift_method: Callable[[ShiftRegister, int, int], Tuple[ShiftRegister, int]],
+    bit_count: int,
+    state: State,
+) -> State:
     """Shifts the given data into the input shift register."""
 
     new_isr, _ = shift_method(
@@ -31,13 +37,17 @@ def shift_into_isr(data_supplier, shift_method, bit_count, state):
     return replace(state, input_shift_register=new_isr)
 
 
-def read_from_osr(state):
+def read_from_osr(state: State) -> int:
     """Reads the contents of the output shift register."""
 
     return state.output_shift_register.contents
 
 
-def shift_from_osr(shift_method, bit_count, state):
+def shift_from_osr(
+    shift_method: Callable[[ShiftRegister, int], Tuple[ShiftRegister, int]],
+    bit_count: int,
+    state: State,
+) -> Tuple[State, int]:
     """Shift the requested number of bits out of the output shift register."""
 
     new_osr, shift_result = shift_method(state.output_shift_register, bit_count)
@@ -51,31 +61,31 @@ def shift_from_osr(shift_method, bit_count, state):
     )
 
 
-def read_from_pin_directions(state):
+def read_from_pin_directions(state: State) -> int:
     """Reads the contents of the pin direction register."""
 
     return state.pin_directions
 
 
-def read_from_pins(state):
+def read_from_pins(state: State) -> int:
     """Reads the contents of the pin values register."""
 
     return state.pin_values
 
 
-def read_from_x(state):
+def read_from_x(state: State) -> int:
     """Reads the contents of the X scratch register."""
 
     return state.x_register
 
 
-def read_from_y(state):
+def read_from_y(state: State) -> int:
     """Reads the contents of the Y scratch register."""
 
     return state.y_register
 
 
-def write_to_isr(data_supplier, state):
+def write_to_isr(data_supplier: Callable[[State], int], state: State) -> State:
     """Copies the given data into the input shift register."""
 
     return replace(
@@ -83,7 +93,7 @@ def write_to_isr(data_supplier, state):
     )
 
 
-def write_to_osr(data_supplier, state):
+def write_to_osr(data_supplier: Callable[[State], int], state: State) -> State:
     """Copies the given data into the output shift register."""
 
     return replace(
@@ -92,37 +102,41 @@ def write_to_osr(data_supplier, state):
     )
 
 
-def write_to_pin_directions(data_supplier, state):
+def write_to_pin_directions(
+    data_supplier: Callable[[State], int], state: State
+) -> State:
     """Copies the given data into the pin directions register."""
 
     return replace(state, pin_directions=data_supplier(state) & 0xFFFF_FFFF)
 
 
-def write_to_pins(data_supplier, state):
+def write_to_pins(data_supplier: Callable[[State], int], state: State) -> State:
     """Copies the given data into the pin values register."""
 
     return replace(state, pin_values=data_supplier(state) & 0xFFFF_FFFF)
 
 
-def write_to_program_counter(data_supplier, state):
+def write_to_program_counter(
+    data_supplier: Callable[[State], int], state: State
+) -> State:
     """Copies the given data into the program counter."""
 
     return replace(state, program_counter=data_supplier(state) & 0x1F)
 
 
-def write_to_x(data_supplier, state):
+def write_to_x(data_supplier: Callable[[State], int], state: State) -> State:
     """Copies the given data into the X scratch register."""
 
     return replace(state, x_register=data_supplier(state) & 0xFFFF_FFFF)
 
 
-def write_to_y(data_supplier, state):
+def write_to_y(data_supplier: Callable[[State], int], state: State) -> State:
     """Copies the given data into the Y scratch register."""
 
     return replace(state, y_register=data_supplier(state) & 0xFFFF_FFFF)
 
 
-def write_to_null(data_supplier, state):
+def write_to_null(data_supplier: Callable[[State], int], state: State) -> State:
     """Discards the given data."""
 
     _ = data_supplier(state)
@@ -130,7 +144,7 @@ def write_to_null(data_supplier, state):
     return state
 
 
-def supplies_value(value):
+def supplies_value(value: Any) -> Callable[[State], Any]:
     """Creates a function that returns the specified value when invoked."""
 
     return lambda _: value

--- a/pioemu/primitive_operations.py
+++ b/pioemu/primitive_operations.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from dataclasses import replace
-from typing import Any, Callable, Tuple
+from typing import Callable, Tuple
 from .state import ShiftRegister, State
 
 
@@ -144,7 +144,7 @@ def write_to_null(data_supplier: Callable[[State], int], state: State) -> State:
     return state
 
 
-def supplies_value(value: Any) -> Callable[[State], Any]:
+def supplies_value(value: int) -> Callable[[State], int]:
     """Creates a function that returns the specified value when invoked."""
 
     return lambda _: value

--- a/pioemu/shift_register.py
+++ b/pioemu/shift_register.py
@@ -11,8 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Self, Tuple
-
+from typing import Tuple
+try:
+	from typing import Self
+except:
+	# For versions of Python < 3.11
+	from typing import TypeVar
+	Self = TypeVar('_Self', bound='A')
 
 class ShiftRegister:
     """Immutable shift register for 32-bit values.

--- a/pioemu/shift_register.py
+++ b/pioemu/shift_register.py
@@ -1,4 +1,4 @@
-# Copyright 2021, 2022 Nathan Young
+# Copyright 2021, 2022, 2023 Nathan Young
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Self, Tuple
+
+
 class ShiftRegister:
     """Immutable shift register for 32-bit values.
 
@@ -26,21 +29,21 @@ class ShiftRegister:
         Total number of bits shifted out of / into this shift register (0-32).
     """
 
-    def __init__(self, contents, counter):
+    def __init__(self, contents: int, counter: int):
         self._contents = contents
         self._counter = counter
 
     @property
-    def contents(self):
+    def contents(self) -> int:
         """Return the value held within this shift register."""
         return self._contents
 
     @property
-    def counter(self):
+    def counter(self) -> int:
         """Return the total number of bits shifted out of / into this shift register."""
         return self._counter
 
-    def shift_left(self, bit_count, data_in=0):
+    def shift_left(self, bit_count: int, data_in: int = 0) -> Tuple[Self, int]:
         """Shifts the most significant bits out of the shift register.
 
         Parameters
@@ -52,7 +55,7 @@ class ShiftRegister:
 
         Returns
         -------
-        (ShiftRegister, int)
+        Tuple[ShiftRegister, int]
             Tuple containing the new representation of this shift register and the result.
         """
         bit_mask = (1 << bit_count) - 1
@@ -66,7 +69,7 @@ class ShiftRegister:
             32 - bit_count
         )
 
-    def shift_right(self, bit_count, data_in=0):
+    def shift_right(self, bit_count: int, data_in: int = 0) -> Tuple[Self, int]:
         """Shifts the least significant bits out of the shift register.
 
         Parameters
@@ -78,7 +81,7 @@ class ShiftRegister:
 
         Returns
         -------
-        (ShiftRegister, int)
+        Tuple[ShiftRegister, int]
             Tuple containing the new representation of this shift register and the result.
         """
         bit_mask = (1 << bit_count) - 1
@@ -93,11 +96,11 @@ class ShiftRegister:
             self._contents & bit_mask,
         )
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if self.__class__ is other.__class__:
             return (self._contents, self._counter) == (other._contents, other._counter)
 
         return NotImplemented
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"ShiftRegister(contents={self._contents!r}, counter={self._counter!r})"

--- a/tests/features/test_delay.py
+++ b/tests/features/test_delay.py
@@ -47,7 +47,7 @@ from ..support import emulate_single_instruction
 )
 # fmt: on
 def test_instruction_consumes_expected_clock_cycles(
-    opcode, initial_state, expected_clock_cycles
+    opcode: int, initial_state: State, expected_clock_cycles: int
 ):
     new_state = emulate_single_instruction(opcode, initial_state)
 

--- a/tests/features/test_shift_register.py
+++ b/tests/features/test_shift_register.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import pytest
 
-from pioemu import ShiftRegister
+from pioemu import ShiftRegister, State
 
 
 # fmt: off

--- a/tests/features/test_shift_register.py
+++ b/tests/features/test_shift_register.py
@@ -41,7 +41,7 @@ from pioemu import ShiftRegister
 )
 # fmt: on
 def test_shift_left(
-    initial_state, bit_count, data_in, expected_state, expected_shift_result
+    initial_state: State, bit_count: int, data_in: int, expected_state: State, expected_shift_result: int
 ):
     new_state, shift_result = initial_state.shift_left(bit_count, data_in)
 
@@ -75,7 +75,7 @@ def test_shift_left(
 )
 # fmt: on
 def test_shift_right(
-    initial_state, bit_count, data_in, expected_state, expected_shift_result
+    initial_state: State, bit_count: int, data_in: int, expected_state: State, expected_shift_result: int
 ):
     new_state, shift_result = initial_state.shift_right(bit_count, data_in)
 

--- a/tests/features/test_side_set.py
+++ b/tests/features/test_side_set.py
@@ -42,7 +42,7 @@ def test_side_set_is_not_mistaken_for_delay():
     ],
 )
 def test_side_set_changes_pin_values(
-    opcode, pin_base, pin_count, initial_pin_values, expected_pin_values
+    opcode: int, pin_base: int, pin_count: int, initial_pin_values: int, expected_pin_values: int
 ):
     _, new_state = next(
         emulate(

--- a/tests/features/test_stop_conditions.py
+++ b/tests/features/test_stop_conditions.py
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from functools import reduce
+from typing import Callable
 
-from pioemu import emulate
+from pioemu import emulate, State
 
 from ..opcodes import Opcodes
 
 
-def _execute_test_program(stop_condition):
+def _execute_test_program(stop_condition: Callable[[int, State], bool]) -> State:
     # Program which decrements the X register from 9 down to 0
     opcodes = [0xE029, 0xA041, 0x0041, Opcodes.nop()]
 

--- a/tests/instructions/test_in.py
+++ b/tests/instructions/test_in.py
@@ -59,7 +59,7 @@ instructions_to_test_with_right_shift = [
 @pytest.mark.parametrize(
     "opcode, initial_state, expected_state", instructions_to_test_with_right_shift
 )
-def test_in_instruction_when_shifting_right(opcode, initial_state, expected_state):
+def test_in_instruction_when_shifting_right(opcode: int, initial_state: State, expected_state: State):
     _, new_state = next(
         emulate(
             [opcode, Opcodes.nop()],

--- a/tests/instructions/test_jmp.py
+++ b/tests/instructions/test_jmp.py
@@ -47,7 +47,7 @@ def test_jump_always_forward():
     ],
 )
 def test_jump_for_scratch_register_conditions(
-    opcode, initial_state, expected_program_counter
+    opcode: int, initial_state: State, expected_program_counter: int
 ):
     new_state = emulate_single_instruction(opcode, initial_state)
 
@@ -87,7 +87,7 @@ def test_jump_when_y_is_non_zero_post_decrement():
         pytest.param(7, State(pin_values=(1 << 7)), 0, id="jmp pin when high"),
     ],
 )
-def test_jump_on_external_control_pin(jmp_pin, initial_state, expected_program_counter):
+def test_jump_on_external_control_pin(jmp_pin: int, initial_state: State, expected_program_counter: int):
     _, new_state = next(
         emulate(
             [0x00C0, Opcodes.nop()],  # jmp pin 0
@@ -115,7 +115,7 @@ def test_jump_on_external_control_pin(jmp_pin, initial_state, expected_program_c
         ),
     ],
 )
-def test_jump_on_output_shift_register_state(initial_state, expected_program_counter):
+def test_jump_on_output_shift_register_state(initial_state: State, expected_program_counter: int):
     new_state = emulate_single_instruction(0x00E2, initial_state)  # jmp !osre, 2
 
     assert new_state.program_counter == expected_program_counter

--- a/tests/instructions/test_mov.py
+++ b/tests/instructions/test_mov.py
@@ -211,7 +211,7 @@ instructions_to_test = [
 
 
 @pytest.mark.parametrize("opcode, initial_state, expected_state", instructions_to_test)
-def test_mov_instruction(opcode, initial_state, expected_state):
+def test_mov_instruction(opcode: int, initial_state: State, expected_state: State):
     new_state = emulate_single_instruction(opcode, initial_state)
 
     assert new_state == expected_state

--- a/tests/instructions/test_out.py
+++ b/tests/instructions/test_out.py
@@ -72,7 +72,7 @@ instructions_to_test_with_right_shift = [
 @pytest.mark.parametrize(
     "opcode, initial_state, expected_state", instructions_to_test_with_left_shift
 )
-def test_out_instruction_when_shifting_left(opcode, initial_state, expected_state):
+def test_out_instruction_when_shifting_left(opcode: int, initial_state: State, expected_state: State):
     _, new_state = next(
         emulate(
             [opcode, Opcodes.nop()],
@@ -88,7 +88,7 @@ def test_out_instruction_when_shifting_left(opcode, initial_state, expected_stat
 @pytest.mark.parametrize(
     "opcode, initial_state, expected_state", instructions_to_test_with_right_shift
 )
-def test_out_instruction_when_shifting_right(opcode, initial_state, expected_state):
+def test_out_instruction_when_shifting_right(opcode: int, initial_state: State, expected_state: State):
     _, new_state = next(
         emulate(
             [opcode, Opcodes.nop()],

--- a/tests/instructions/test_pull.py
+++ b/tests/instructions/test_pull.py
@@ -52,7 +52,7 @@ def test_pull_stalls_when_blocking_and_fifo_empty():
         pytest.param(0x80A0, id="pull block"),
     ],
 )
-def test_pull_clears_the_output_shift_register(opcode):
+def test_pull_clears_the_output_shift_register(opcode: int):
     initial_state = State(transmit_fifo=deque([0]))
 
     new_state = emulate_single_instruction(opcode, initial_state)

--- a/tests/instructions/test_wait.py
+++ b/tests/instructions/test_wait.py
@@ -25,7 +25,7 @@ from ..support import emulate_single_instruction
         pytest.param(0x2020, State(pin_values=1), id="wait 0 pin, 0"),
     ],
 )
-def test_wait_stalls_when_condition_not_met(opcode, initial_state):
+def test_wait_stalls_when_condition_not_met(opcode: int, initial_state: State):
     new_state = emulate_single_instruction(opcode, initial_state)
 
     assert new_state.program_counter == 0
@@ -38,7 +38,7 @@ def test_wait_stalls_when_condition_not_met(opcode, initial_state):
         pytest.param(0x2020, State(pin_values=0), id="wait 0 pin, 0"),
     ],
 )
-def test_wait_advances_when_condition_met(opcode, initial_state):
+def test_wait_advances_when_condition_met(opcode: int, initial_state: State):
     new_state = emulate_single_instruction(opcode, initial_state)
 
     assert new_state.program_counter == 1

--- a/tests/opcodes.py
+++ b/tests/opcodes.py
@@ -13,5 +13,5 @@
 # limitations under the License.
 class Opcodes:
     @staticmethod
-    def nop():
+    def nop() -> int:
         return 0xA042

--- a/tests/support.py
+++ b/tests/support.py
@@ -15,7 +15,7 @@ from dataclasses import replace
 
 from pytest import param
 
-from pioemu import clock_cycles_reached, emulate
+from pioemu import clock_cycles_reached, emulate, State
 
 from .opcodes import Opcodes
 
@@ -33,7 +33,7 @@ def instruction_param(
     return param(opcode, initial_state, expected_state, id=description)
 
 
-def emulate_single_instruction(opcode, initial_state=None):
+def emulate_single_instruction(opcode: int, initial_state=None) -> State:
     if initial_state is not None:
         instruction_generator = emulate(
             [opcode, Opcodes.nop()],

--- a/tests/test_emulation.py
+++ b/tests/test_emulation.py
@@ -39,7 +39,7 @@ def test_emulation_stops_when_unsupported_opcode_is_reached():
         pytest.param(0x7F40, id="out y, 32 [31]"),
     ],
 )
-def test_program_counter_is_incremented(opcode):
+def test_program_counter_is_incremented(opcode: int):
     initial_state = State(program_counter=0)
 
     new_state = emulate_single_instruction(opcode, initial_state)


### PR DESCRIPTION
Fixes Python versions < 3.11 and adds some type-hinting to the tests (not sure if that's actually needed since they have decorators that seem to describe the types but I figured I'd do it in case it helps)