### PR TITLE
Support type-hints on user provided input_sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Added
+- Support `input_source`'s with different signatures.
+
 ### Changed
 - Updated dependencies used for development.
 - Updated dependencies used by examples.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -9,15 +9,24 @@ at that time. The example below toggles the value present on GPIO pin 0 with
 each clock cycle.
 
 ```python
-from pioemu import emulate
+from pioemu import emulate, State
 
 program = [0xA020]  # mov pins, x
 
-def incoming_signals(clock: int) -> int:
-    return 1 - (clock % 2)  # Toggle the value present on GPIO 0
+def incoming_signals(state: State) -> int:
+    return 1 - (state.clock % 2)  # Toggle the value present on GPIO 0
 
 for before, after in emulate(
     program, input_source=incoming_signals, stop_when=lambda _, state: state.clock > 3
 ):
     print(f"[{after.clock}] GPIO: {before.pin_values:b} -> {after.pin_values:b}")
+```
+
+An `input_source` can be defined to take either a `State` object or an `int`
+value (which represents the current clock cycle). The following implementation
+is equivalent to the one in the example above.
+
+```python
+def incoming_signals(clock: int) -> int:
+    return 1 - (clock % 2)  # Toggle the value present on GPIO 0
 ```

--- a/docs/images/coverage-badge.svg
+++ b/docs/images/coverage-badge.svg
@@ -17,7 +17,7 @@
         <text x="32.5" y="14">coverage</text>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
-        <text x="89.0" y="15" fill="#010101" fill-opacity=".3">97.1%</text>
-        <text x="88.0" y="14">97.1%</text>
+        <text x="89.0" y="15" fill="#010101" fill-opacity=".3">96.4%</text>
+        <text x="88.0" y="14">96.4%</text>
     </g>
 </svg>

--- a/docs/images/coverage-badge.svg
+++ b/docs/images/coverage-badge.svg
@@ -17,7 +17,7 @@
         <text x="32.5" y="14">coverage</text>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
-        <text x="89.0" y="15" fill="#010101" fill-opacity=".3">97.0%</text>
-        <text x="88.0" y="14">97.0%</text>
+        <text x="89.0" y="15" fill="#010101" fill-opacity=".3">97.1%</text>
+        <text x="88.0" y="14">97.1%</text>
     </g>
 </svg>

--- a/pioemu/emulation.py
+++ b/pioemu/emulation.py
@@ -154,12 +154,12 @@ def _normalize_input_source(logger: logging.Logger, input_source: Callable):
     if parameter_type == State:
         return input_source
     elif parameter_type == int:
-        return _wrap_deprecated_input_source(input_source)
+        return lambda state: input_source(state.clock)
     elif parameter_type is None:
         logger.warning(
             "input_source is missing type hints/annotations and may not work as expected"
         )
-        return _wrap_deprecated_input_source(input_source)
+        return lambda state: input_source(state.clock)
     else:
         raise ValueError("Unsupported signature for input_source")
 
@@ -173,10 +173,6 @@ def _get_input_source_parameter_type(input_source: Callable):
     parameter_type = parameters[0].annotation
 
     return parameter_type if parameter_type != inspect._empty else None
-
-
-def _wrap_deprecated_input_source(input_source: Callable[[int], int]):
-    return lambda state: input_source(state.clock)
 
 
 def _advance_program_counter(

--- a/pioemu/emulation.py
+++ b/pioemu/emulation.py
@@ -161,7 +161,6 @@ def _is_input_source_signature_supported(input_source: Callable):
 
 
 def _wrap_deprecated_input_source(input_source: Callable[[int], int]):
-    print("Wrapping!")
     return lambda state: input_source(state.clock)
 
 

--- a/tests/features/test_input_source.py
+++ b/tests/features/test_input_source.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Nathan Young
+# Copyright 2023, 2024 Nathan Young
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -42,12 +42,15 @@ def test_updating_of_pin_values_from_input_source(
 ):
     initial_state = State(pin_directions=pin_directions, pin_values=pin_values)
 
+    def constant_input_source(_: State):
+        return value_from_input_source
+
     _, new_state = next(
         emulate(
             [Opcodes.nop()],
             stop_when=clock_cycles_reached(1),
             initial_state=initial_state,
-            input_source=lambda _: value_from_input_source,
+            input_source=constant_input_source,
         )
     )
 
@@ -57,13 +60,32 @@ def test_updating_of_pin_values_from_input_source(
 def test_pin_values_follow_input_source():
     input_values_over_time = [0x0000_FFFF, 0xFFFF_0000, 0xFFFF_FFFF]
 
+    def varying_input_source(state: State):
+        return input_values_over_time[state.clock]
+
     pin_values_series = [
         state.pin_values
         for _, state in emulate(
             [Opcodes.nop()],
             stop_when=clock_cycles_reached(len(input_values_over_time)),
-            input_source=lambda clock: input_values_over_time[clock],
+            input_source=varying_input_source,
         )
     ]
 
     assert pin_values_series == input_values_over_time
+
+
+def test_support_for_deprecated_input_source():
+    def input_source_without_type_hints(clock):
+        assert clock == 0
+        return 0x5555_5555
+
+    _, state = next(
+        emulate(
+            [Opcodes.nop()],
+            stop_when=clock_cycles_reached(1),
+            input_source=input_source_without_type_hints,
+        )
+    )
+
+    assert state.pin_values == 0x5555_5555


### PR DESCRIPTION
This change encourages but does not mandate the use of type annotations/hints on user provided input sources.