### PR TITLE
Fix error running unit test from command line

### DIFF
--- a/tests/decoding/__init__.py
+++ b/tests/decoding/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2025 Nathan Young
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.


### PR DESCRIPTION
Add missing `__init__.py` file to allow all unit tests to be run from the command line.