### PR TITLE
Ensure that post-decrement ops decrement from 0 to 0xFFFF_FFFF.

### DIFF
--- a/pioemu/emulation.py
+++ b/pioemu/emulation.py
@@ -329,9 +329,9 @@ def _apply_side_effects(
             output_shift_register=new_output_shift_register,
         )
     elif (opcode & 0xE0E0) == 0x0040:
-        return replace(state, x_register=state.x_register - 1)
+        return replace(state, x_register=(state.x_register - 1) & 0xFFFF_FFFF)
     elif (opcode & 0xE0E0) == 0x0080:
-        return replace(state, y_register=state.y_register - 1)
+        return replace(state, y_register=(state.y_register - 1) & 0xFFFF_FFFF)
 
     return state
 

--- a/tests/instructions/test_jmp.py
+++ b/tests/instructions/test_jmp.py
@@ -82,6 +82,16 @@ def test_jump_when_y_is_non_zero_post_decrement():
     assert y_register_series == [0, 3, 2, 1, 0]
 
 
+def test_jump_x_post_decrement_wraps_from_zero_to_max():
+    _, new_state = emulate_single_instruction(0x0041, initial_state=State(x_register=0))
+    assert new_state.x_register == 0xFFFF_FFFF
+
+
+def test_jump_y_post_decrement_wraps_from_zero_to_max():
+    _, new_state = emulate_single_instruction(0x0081, initial_state=State(y_register=0))
+    assert new_state.y_register == 0xFFFF_FFFF
+
+
 @pytest.mark.parametrize(
     "jmp_pin, initial_state, expected_program_counter",
     [


### PR DESCRIPTION
The post-decrement JMP instructions were decrementing the X and Y registers from 0 to -1 instead of 0xFFFF_FFFF. This PR fixes this, and adds a test.